### PR TITLE
chore: group dependabot updates and pin actions to commit hashes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,19 @@
 version: 2
 updates:
-  - package-ecosystem: github-actions
-    directory: /
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: monthly
+      interval: "monthly"
+    groups:
+      all-actions:
+        patterns:
+          - "*"
 
-  - package-ecosystem: gomod
-    directory: /
+  - package-ecosystem: "gomod"
+    directory: "/"
     schedule:
-      interval: monthly
+      interval: "monthly"
+    groups:
+      patch:
+        update-types:
+          - "patch"

--- a/.github/workflows/build-and-lint.yml
+++ b/.github/workflows/build-and-lint.yml
@@ -7,10 +7,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
@@ -21,13 +21,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,10 +32,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
@@ -53,7 +53,7 @@ jobs:
           shasum -a 256 ${{ matrix.name }}.tar.gz > ${{ matrix.name }}.tar.gz.sha256
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.name }}
           path: dist/${{ matrix.name }}.tar.gz*
@@ -63,10 +63,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           path: artifacts
           merge-multiple: true


### PR DESCRIPTION
## Summary

Standardize Dependabot grouping rules and pin GitHub Actions to commit hashes.

- Add `patch` group (`update-types: ["patch"]`) for non-actions / non-terraform ecosystems so that patch-level updates land in a single PR.
- Group all GitHub Actions into `all-actions` and Terraform providers into `all-providers` (where applicable).
- Pin all GitHub Actions referenced in `.github/workflows/*.yml` to commit hashes using [pinact](https://github.com/suzuki-shunsuke/pinact). The version comment after each hash lets Dependabot continue to bump them.

## Test plan

- [ ] Confirm Dependabot UI accepts the new config (no errors on next scheduled run)
- [ ] Confirm existing workflows still pass